### PR TITLE
Workaround for REST API inserting/publishing.

### DIFF
--- a/includes/share-functions.php
+++ b/includes/share-functions.php
@@ -5,6 +5,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+function ppp_post_inserted( $post_id, $post, $updated ) {
+	if ( ! $updated ) {
+		ppp_share_on_publish( $post->post_status, 'draft', $post );
+	}
+}
+
+function ppp_post_updated( $post_id, $post_after, $post_before ) {
+	ppp_share_on_publish( $post_after->post_status, $post_before->post_status, $post_after );
+}
+
 /**
  * Determine if we should share this post when it's being published
  *

--- a/post-promoter-pro.php
+++ b/post-promoter-pro.php
@@ -106,7 +106,8 @@ class PostPromoterPro {
 
 		add_action( 'init', array( $this, 'get_actions' ) );
 		add_action( 'save_post', 'ppp_schedule_share', 99, 2);
-		add_action( 'transition_post_status', 'ppp_share_on_publish', 99, 3);
+		add_action( 'wp_insert_post', 'ppp_post_inserted', 99, 3 );
+		add_action( 'post_updated', 'ppp_post_updated', 99, 3 );
 		add_action( 'init', 'ppp_add_image_sizes' );
 		add_filter( 'wp_log_types', array( $this, 'register_log_type' ), 10, 1 );
 	}


### PR DESCRIPTION
Due to the REST API directly calling wp_insert_post, transition_post_status wasn't firing, so actions weren't run. This solution isn't ideal, but it'll fix it.

Note: not fully tested.