### PR TITLE
Use `manage_options` instead of `administrator` for determining caps

### DIFF
--- a/includes/admin/actions.php
+++ b/includes/admin/actions.php
@@ -16,7 +16,7 @@ function ppp_disconnect_social() {
 
 	if ( isset( $_GET['ppp_social_disconnect'] ) && isset( $_GET['ppp_network'] ) ) {
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( PostPromoterPro::get_manage_capability() ) ) {
 			wp_die( __( 'You do not have permission to view this page', 'ppp-txt' ) );
 		}
 

--- a/includes/admin/dashboard.php
+++ b/includes/admin/dashboard.php
@@ -17,7 +17,7 @@ class PPP_Dashboard_Shares {
 	 * @since  2.2.3
 	 */
 	public static function init() {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( PostPromoterPro::get_manage_capability() ) ) {
 			return;
 		}
 

--- a/includes/admin/upgrades.php
+++ b/includes/admin/upgrades.php
@@ -133,7 +133,7 @@ function ppp_v21_upgrades() {
  */
 function ppp_v22_postmeta_upgrade() {
 
-	if( ! current_user_can( 'manage_options' ) ) {
+	if( ! current_user_can( PostPromoterPro::get_manage_capability() ) ) {
 		wp_die( __( 'You do not have permission to do upgrades', 'ppp-txt' ), __( 'Error', 'ppp-txt' ), array( 'response' => 403 ) );
 	}
 

--- a/includes/admin/welcome.php
+++ b/includes/admin/welcome.php
@@ -25,11 +25,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class PPP_Welcome {
 
 	/**
-	 * @var string The capability users should have to view the page
-	 */
-	public $minimum_capability = 'manage_options';
-
-	/**
 	 * Get things started
 	 *
 	 * @since 1.2
@@ -53,7 +48,7 @@ class PPP_Welcome {
 		add_dashboard_page(
 			__( 'Welcome to Post Promoter Pro', 'ppp-txt' ),
 			__( 'Welcome to Post Promoter Pro', 'ppp-txt' ),
-			$this->minimum_capability,
+			PostPromoterPro::get_manage_capability(),
 			'ppp-about',
 			array( $this, 'about_screen' )
 		);
@@ -62,7 +57,7 @@ class PPP_Welcome {
 		add_dashboard_page(
 			__( 'Getting started with Post Promoter Pro', 'ppp-txt' ),
 			__( 'Getting started with Post Promoter Pro', 'ppp-txt' ),
-			$this->minimum_capability,
+			PostPromoterPro::get_manage_capability(),
 			'ppp-getting-started',
 			array( $this, 'getting_started_screen' )
 		);

--- a/includes/twitter-functions.php
+++ b/includes/twitter-functions.php
@@ -129,7 +129,7 @@ add_action( 'admin_head', 'ppp_capture_twitter_oauth', 10 );
 function ppp_disconnect_twitter() {
 	if ( ! empty( $_GET['user_id'] ) ) {
 		$user_id = (int) sanitize_text_field( $_GET['user_id'] );
-		if ( $user_id !== get_current_user_id() || ! current_user_can( 'manage_options' ) ) {
+		if ( $user_id !== get_current_user_id() || ! current_user_can( PostPromoterPro::get_manage_capability() ) ) {
 			wp_die( __( 'Unable to disconnect Twitter account', 'ppp-txt' ) );
 		}
 		delete_user_meta( $user_id, '_ppp_twitter_data' );
@@ -879,7 +879,7 @@ function ppp_tw_profile_settings( $user ) {
 		return;
 	}
 
-	if ( $user->ID !== get_current_user_id() && ! current_user_can( 'manage_options' ) ) {
+	if ( $user->ID !== get_current_user_id() && ! current_user_can( PostPromoterPro::get_manage_capability() ) ) {
 		return;
 	}
 

--- a/post-promoter-pro.php
+++ b/post-promoter-pro.php
@@ -182,17 +182,26 @@ class PostPromoterPro {
 	}
 
 	/**
+	 * Returns the capability (or role) required to manage the plugin.
+	 *
+	 * @return string A WordPress capability or role name.
+	 */
+	public static function get_manage_capability() {
+		return apply_filters( 'ppp_manage_role', 'manage_options' );
+	}
+
+	/**
 	 * Add the Pushover Notifications item to the Settings menu
 	 * @return void
 	 * @access public
 	 */
 	public function ppp_setup_admin_menu() {
-		$role = apply_filters( 'ppp_manage_role', 'administrator' );
+		$capability = self::get_manage_capability();
 
 		add_menu_page(
 			__( 'Post Promoter', 'ppp-txt' ),
 			__( 'Post Promoter', 'ppp-txt' ),
-			$role,
+			$capability,
 			'ppp-options',
 			'ppp_admin_page'
 		);
@@ -201,7 +210,7 @@ class PostPromoterPro {
 			'ppp-options',
 			__( 'Social Settings', 'ppp-txt' ),
 			__( 'Social Settings', 'ppp-txt' ),
-			$role,
+			$capability,
 			'ppp-social-settings',
 			'ppp_display_social'
 		);
@@ -210,7 +219,7 @@ class PostPromoterPro {
 			'ppp-options',
 			__( 'Schedule', 'ppp-txt' ),
 			__( 'Schedule', 'ppp-txt' ),
-			$role,
+			$capability,
 			'ppp-schedule-info',
 			'ppp_display_schedule'
 		);
@@ -219,7 +228,7 @@ class PostPromoterPro {
 			'ppp-options',
 			__( 'System Info', 'ppp-txt' ),
 			__( 'System Info', 'ppp-txt' ),
-			$role,
+			$capability,
 			'ppp-system-info',
 			'ppp_display_sysinfo'
 		);
@@ -228,7 +237,7 @@ class PostPromoterPro {
 			null,
 			__( 'PPP Upgrades', 'ppp-txt' ),
 			__( 'PPP Upgrades', 'ppp-txt' ),
-			$role,
+			$capability,
 			'ppp-upgrades',
 			'ppp_upgrades_screen'
 		);

--- a/tests/tests-filters.php
+++ b/tests/tests-filters.php
@@ -68,4 +68,15 @@ class Tests_Filters extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $link );
 	}
 
+	public function test_ppp_manage_role_filter() {
+		$callback = function() {
+			return 'another_cap';
+		};
+
+		add_filter( 'ppp_manage_role', $callback );
+		$this->assertEquals( 'another_cap', PostPromoterPro::get_manage_capability() );
+		remove_filter( 'ppp_manage_role', $callback );
+		$this->assertEquals( 'manage_options', PostPromoterPro::get_manage_capability() );
+	}
+
 }


### PR DESCRIPTION
* Introduces `PostPromoterPro::get_manage_capability()`, which returns `manage_options` unless modified by the `ppp_manage_role` filter.
* Uses `PostPromoterPro::get_manage_capability()` consistently thoughout the code, instead of hardcoding `manage_options` a bunch of times, making `ppp_manage_role` useful as a filter.
* Unit tests for `PostPromoterPro::get_manage_capability()` and `ppp_manage_role`.
    
fixes postpromoterpro/post-promoter-pro#275