### PR TITLE
Fix: delete_user_meta() requires two arguments

### DIFF
--- a/includes/libs/twitter-user.php
+++ b/includes/libs/twitter-user.php
@@ -46,7 +46,7 @@ if( !class_exists( 'PPP_Twitter_User' ) ) {
 		}
 
 		public function revoke_access() {
-			delete_user_meta( '_ppp_twitter_data' );
+			delete_user_meta( $this->user_id, '_ppp_twitter_data' );
 		}
 
 		/**


### PR DESCRIPTION
https://codex.wordpress.org/Function_Reference/delete_user_meta

The `delete_user_meta()` function requires two arguments, the `$user_id` and `$meta_key`.

In [`revoke_access()` found in twitter-user.php](https://github.com/postpromoterpro/post-promoter-pro/blob/master/includes/libs/twitter-user.php#L49) only one argument was passed to the function.

This PR fixes that.